### PR TITLE
fix: remove word typo

### DIFF
--- a/src/poem.txt
+++ b/src/poem.txt
@@ -12,7 +12,7 @@ Music starts
 
 I just wanna tell you how I'm feeling
 Gotta make you understand
-Never gonna give you ip
+Never gonna give you up
 Never gonna let you down
 
 Never gonna run around and desert you


### PR DESCRIPTION
fixed a word typo from "ip" to "up"